### PR TITLE
Recheck for gateways if there isn't one saved

### DIFF
--- a/src/lnurlp.rs
+++ b/src/lnurlp.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use crate::{
     invoice::{spawn_invoice_subscription, InvoiceState},
+    mint::select_gateway,
     models::{invoice::NewInvoice, zaps::NewZap},
     routes::{LnurlCallbackParams, LnurlCallbackResponse, LnurlVerifyResponse},
     State,
@@ -103,11 +104,9 @@ pub async fn lnurl_callback(
 
     let invoice_index = user.invoice_index;
 
-    let gateway = state
-        .mm
-        .get_gateway(federation_id)
+    let gateway = select_gateway(&client)
         .await
-        .ok_or(anyhow!("Not gateway configured for federation"))?;
+        .ok_or(anyhow!("No gateway found for federation"))?;
 
     let (op_id, pr, preimage) = ln
         .create_bolt11_invoice_for_user_tweaked(


### PR DESCRIPTION
I am getting this currently: https://hermes-blinded-staging.fly.dev/lnurlp/test1234/callback?amount=10000

I assume because we don't durably save the fedimint db that we can lose the gateways we've been told about.

Finding a gateway is just lookups in the fedimint database so this shouldn't block requests.
